### PR TITLE
Add missing DescribeScheduledActions action to AWS policy

### DIFF
--- a/docs/providers/aws/authentication.mdx
+++ b/docs/providers/aws/authentication.mdx
@@ -336,7 +336,8 @@ As AWS documentation recommends, the below policy is granting only the permissio
                 "rds:DescribeGlobalClusters",
                 "application-autoscaling:DescribeScalableTargets",
                 "rds:DescribeGlobalClusters",
-                "application-autoscaling:DescribeScalingPolicies"
+                "application-autoscaling:DescribeScalingPolicies",
+                "application-autoscaling:DescribeScheduledActions"
             ]
         }
     ]


### PR DESCRIPTION
While scanning using the latest policy, I get the following error

```
Ignoring aws_appautoscaling_scheduled_action from drift calculation: Listing aws_appautoscaling_scheduled_action is forbidden: AccessDeniedException: User: arn:aws:sts::XXXX:assumed-role/driftctl_assume_role/XXXXX is not authorized to perform: application-autoscaling:DescribeScheduledActions because no identity-based policy allows the application-autoscaling:DescribeScheduledActions action
	status code: 400, request id: XXXX
```