### PR TITLE
Document support for aws_apigatewayv2_route

### DIFF
--- a/docs/providers/aws/resources.mdx
+++ b/docs/providers/aws/resources.mdx
@@ -86,5 +86,6 @@ title: Supported Resources
 | aws_rds_cluster_instance | ✅ |
 | aws_appautoscaling_policy | ✅ |
 | aws_appautoscaling_scheduled_action | ❌ |
+| aws_apigatewayv2_route | ❌ |
 | aws_apigatewayv2_vpc_link | ❌ |
 | aws_launch_template | ✅ |


### PR DESCRIPTION
Introduced in https://github.com/snyk/driftctl/pull/1252. Don't merge this until that's accepted!