### PR TITLE
Add aws_apigatewayv2_api

### DIFF
--- a/versioned_docs/version-0.17.0/providers/aws/resources.mdx
+++ b/versioned_docs/version-0.17.0/providers/aws/resources.mdx
@@ -77,6 +77,7 @@ title: Supported Resources
 | aws_api_gateway_method_settings | ❌ |
 | aws_api_gateway_integration | ❌ |
 | aws_api_gateway_integration_response | ❌ |
+| aws_apigatewayv2_api | ❌ |
 | aws_appautoscaling_target | ✅ |
 | aws_default_network_acl | ✅ |
 | aws_network_acl | ✅ |


### PR DESCRIPTION
The resource is missing in v0.17.

Closes #198 