### PR TITLE
Create release automation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,5 @@ jobs:
         run: |
           git config --global user.email "actions@gihub.com"
           git config --global user.name "gh-actions"
-          npm run auto-versioning
+          npm run release-latest-version
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+
+on:
+  repository_dispatch:
+    types: [new_version]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          cache: 'npm'
+      - uses: bahmutov/npm-install@v1
+      - name: Create and commit new version
+        run: |
+          git config --global user.email "actions@gihub.com"
+          git config --global user.name "gh-actions"
+          npm run auto-versioning
+          git push

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "serve": "docusaurus serve",
     "clear": "docusaurus clear",
     "versioning": "docusaurus docs:version",
+    "auto-versioning": "./scripts/auto-versioning.sh",
     "prepare": "husky install",
     "format": "prettier --check '**/*.{js,jsx}'",
     "format:fix": "prettier --write '**/*.{js,jsx}'"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "serve": "docusaurus serve",
     "clear": "docusaurus clear",
     "versioning": "docusaurus docs:version",
-    "auto-versioning": "./scripts/auto-versioning.sh",
+    "release-latest-version": "./scripts/release-latest-version.sh",
     "prepare": "husky install",
     "format": "prettier --check '**/*.{js,jsx}'",
     "format:fix": "prettier --write '**/*.{js,jsx}'"

--- a/scripts/auto-versioning.sh
+++ b/scripts/auto-versioning.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+VERSION=$(curl -s https://api.github.com/repos/snyk/driftctl/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')
+MINOR_VERSION=$(echo $VERSION | sed 's/\.[[:digit:]]\+$//g')
+
+echo "Running script for version $VERSION (minor: $MINOR_VERSION)"
+
+# Check if the version already exist
+if cat versions.json | grep -q $VERSION &>/dev/null; then
+  echo "Skipping new version $VERSION since it already exist"
+  exit 0
+fi
+
+# Check if the version is a patch release
+if cat versions.json | grep $MINOR_VERSION -q &>/dev/null; then
+  echo "Skipping new version $VERSION since it's a patch release"
+  exit 0
+fi
+
+# Create the version
+npm run versioning $VERSION
+
+git add . && git commit -m "release: create version $VERSION"

--- a/scripts/auto-versioning.sh
+++ b/scripts/auto-versioning.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 VERSION=$(curl -s https://api.github.com/repos/snyk/driftctl/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')
-MINOR_VERSION=$(echo $VERSION | sed 's/\.[[:digit:]]\+$//g')
+MINOR_VERSION="$(echo "$VERSION" | sed 's/\.[[:digit:]]\+$//g')"
 
 echo "Running script for version $VERSION (minor: $MINOR_VERSION)"
 
 # Check if the version already exist
 if cat versions.json | grep -q $VERSION &>/dev/null; then
-  echo "Skipping new version $VERSION since it already exist"
+  echo "Skipping new version $VERSION since it already exists"
   exit 0
 fi
 

--- a/scripts/release-latest-version.sh
+++ b/scripts/release-latest-version.sh
@@ -8,13 +8,13 @@ MINOR_VERSION="$(echo "$VERSION" | sed 's/\.[[:digit:]]\+$//g')"
 echo "Running script for version $VERSION (minor: $MINOR_VERSION)"
 
 # Check if the version already exist
-if cat versions.json | grep -q $VERSION &>/dev/null; then
+if cat versions.json | grep -q "$VERSION" &>/dev/null; then
   echo "Skipping new version $VERSION since it already exists"
   exit 0
 fi
 
 # Check if the version is a patch release
-if cat versions.json | grep $MINOR_VERSION -q &>/dev/null; then
+if cat versions.json | grep "$MINOR_VERSION" -q &>/dev/null; then
   echo "Skipping new version $VERSION since it's a patch release"
   exit 0
 fi


### PR DESCRIPTION
Currently, the documentation of driftctl is located in another Git repo (snyk/driftctl-docs). Merging in main branch triggers a deployment of the website. Each time we release a new version of driftctl, we have to manually create a new branch with the new version, create a PR for it, wait for approval then merge and deploy it to production. That’s a really long process that doesn’t fit with our needs anymore, as we want to release more often and quicker.

It’s actually possible to trigger a GitHub action pipeline manually using the dispatch event of the GitHub API. This PR adds a release workflow to automatically create a new version based on the latest driftctl version. The script checks whether if the version already exist or if it's a patch release. This action will then be triggered by a webhook in the driftctl repo, introduced by https://github.com/snyk/driftctl/pull/1318.

Example command to trigger this workflow : 

```shell
$ curl -X POST https://api.github.com/repos/snyk/driftctl-docs/dispatches \
  -d '{"event_type": "new_version"}' \
  -H 'Authorization: token $GITHUB_TOKEN
```

**Note to maintainers**

- I have tested this workflow in a test repository, as weird as it sounds, it doesn't need any extra credentials to work since GitHub already provide a token to access the repository
- Merging this will fixes #84 