### PR TITLE
Add workflow_run to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_run:
+    workflows: ["release"]
+    types:
+      - completed
 
 jobs:
   checks:


### PR DESCRIPTION
**Description**

For some reason, when the github-action user pushes to the main branch, the deploy workflow is not triggered. I assume this is because this user can't trigger workflows the way a normal user does. This PR enforce running the deploy workflow when the release workflow succeeded.

**References**

- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run