### PR TITLE
chore: changing expiry on vulns ignores

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,20 +6,20 @@ ignore:
     - '*':
         reason: Unreachable as tool is used for static site generation
         created: '2022-01-18T14:54:43.796Z'
-        expires: '2022-04-18T14:54:43.796Z'
+        expires: '2022-06-18T14:54:43.796Z'
   SNYK-JS-ASYNC-2441827:
     - '*':
         reason: Unreachable as tool is used for static site generation
         created: '2022-01-18T14:54:43.796Z'
-        expires: '2022-04-18T14:54:43.797Z'
+        expires: '2022-06-18T14:54:43.797Z'
   SNYK-JS-NTHCHECK-1586032:
     - '*':
         reason: Unreachable as tool is used for static site generation
         created: '2022-01-18T14:54:43.796Z'
-        expires: '2022-04-18T14:54:43.797Z'
+        expires: '2022-06-18T14:54:43.797Z'
   SNYK-JS-TRIM-1017038:
     - '*':
         reason: Unreachable as tool is used for static site generation
         created: '2022-01-18T14:54:43.796Z'
-        expires: '2022-04-18T14:54:43.797Z'
+        expires: '2022-06-18T14:54:43.797Z'
 patch: {}


### PR DESCRIPTION
Still no updates on docusaurus framework for these 4 vulns.

Changed the expiry dates.