### PR TITLE
Document the Glob pattern for Cloud storage solutions

### DIFF
--- a/docs/usage/cmd/scan.mdx
+++ b/docs/usage/cmd/scan.mdx
@@ -70,7 +70,11 @@ $ driftctl scan --from tfstate://my-states/directory/*.tfstate
 
 # Using glob pattern to recursively use any *.tfstate file.
 $ driftctl scan --from tfstate://path/to/**/*.tfstate
-$ driftctl scan --from tfstate+s3://path/to/**/*.tfstate
+$ driftctl scan --from tfstate+s3://example-bucket/*.tfstate
+$ driftctl scan --from tfstate+gs://example-bucket/**/*.tfstate
+$ driftctl scan --from tfstate+azurerm://example-container/states/*.tfstate
+
+# This works for 
 
 # We also support HTTP(s) URLs with authentication
 # the tool will fetch the file from the given URL

--- a/docs/usage/cmd/scan.mdx
+++ b/docs/usage/cmd/scan.mdx
@@ -56,9 +56,6 @@ $ driftctl scan \
   --from tfstate+s3://statebucketdriftctl/terraform.tfstate \
   --from tfstate://terraform_toto.tfstate
 
-# You can also read all files under a given prefix for S3
-$ driftctl scan --from tfstate+s3://statebucketdriftctl/states
-
 # In a given local folder
 # driftctl will recursively use all files under this folder.
 #


### PR DESCRIPTION
complementary to [#1608](https://github.com/snyk/driftctl/pull/1608)

- Removed a non-existent feature (found out when working on the above mentioned PR)
- Reference gs, azurerm and s3 in the glob pattern example