### PR TITLE
Add DCTL_FROM to the Github actions example

### DIFF
--- a/versioned_docs/version-0.38.0/ci_cd/guides/ghaction.mdx
+++ b/versioned_docs/version-0.38.0/ci_cd/guides/ghaction.mdx
@@ -29,6 +29,7 @@ jobs:
         uses: snyk/driftctl-action@v1
         env:
           DCTL_FILTER: "Type=='aws_instance'"
+          DCTL_FROM: tfstate://terraform.tfstate
         with:
           version: 0.6.0
 ```


### PR DESCRIPTION
There is no mention of how to change the DCTL_FROM in the workflow in the documentation. This might cause confusion. Adding this to the documentation will help users and clarify it's use case.