### PR TITLE
chore: ignore some Snyk issues

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,10 +6,35 @@ ignore:
     - '*':
         reason: Unreachable as tool is used for static site generation
         created: 2022-06-20T09:28:43.796Z
-        expires: 2022-12-23T14:29:55.313Z
+        expires: 2023-05-04T16:15:19.065Z
   SNYK-JS-TRIM-1017038:
     - '*':
         reason: Unreachable as tool is used for static site generation
         created: 2022-01-18T14:54:43.796Z
-        expires: 2022-12-23T14:29:55.313Z
+        expires: 2023-05-04T16:15:19.065Z
+  SNYK-JS-ETA-2936803:
+    - '*':
+        reason: Unreachable as tool is used for static site generation
+        created: 2023-02-02T16:15:19.071Z
+        expires: 2023-05-04T16:15:19.065Z
+  SNYK-JS-ETA-3261240:
+    - '*':
+        reason: Unreachable as tool is used for static site generation
+        created: 2023-02-02T16:15:19.071Z
+        expires: 2023-05-04T16:15:19.065Z
+  SNYK-JS-HTTPCACHESEMANTICS-3248783:
+    - '*':
+        reason: Unreachable as tool is used for static site generation
+        created: 2023-02-02T16:15:19.071Z
+        expires: 2023-05-04T16:15:19.065Z
+  SNYK-JS-JSON5-3182856:
+    - '*':
+        reason: Unreachable as tool is used for static site generation
+        created: 2023-02-02T16:15:19.071Z
+        expires: 2023-05-04T16:15:19.065Z
+  SNYK-JS-UAPARSERJS-3244450:
+    - '*':
+        reason: Unreachable as tool is used for static site generation
+        created: 2023-02-02T16:15:19.071Z
+        expires: 2023-05-04T16:15:19.065Z
 patch: {}


### PR DESCRIPTION
Ignore a new issue in a transitive dependency, extend the expiry dates of 2 other ignore rules, and ignore 4 more that had been issues for some time. All of these packages are transitive dependencies of docusaurus, which is only used to generate a static site, and does not take user input, so we think none of the issues are reachable.