### PR TITLE
fix: dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "website",
       "version": "0.0.1",
       "dependencies": {
-        "@docusaurus/core": "^2.4.0",
-        "@docusaurus/plugin-client-redirects": "^2.4.0",
-        "@docusaurus/preset-classic": "^2.4.0",
+        "@docusaurus/core": "^2.4.1",
+        "@docusaurus/plugin-client-redirects": "^2.4.1",
+        "@docusaurus/preset-classic": "^2.4.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
         "prism-react-renderer": "^1.3.3",
@@ -24,19 +24,31 @@
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
-      "integrity": "sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.4"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
-      "integrity": "sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.4"
+        "@algolia/autocomplete-shared": "1.9.3"
       },
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -44,79 +56,83 @@
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
-      "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.16.0.tgz",
-      "integrity": "sha512-jVrk0YB3tjOhD5/lhBtYCVCeLjZmVpf2kdi4puApofytf/R0scjWz0GdozlW4HhU+Prxmt/c9ge4QFjtv5OAzQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.19.1.tgz",
+      "integrity": "sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==",
       "dependencies": {
-        "@algolia/cache-common": "4.16.0"
+        "@algolia/cache-common": "4.19.1"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.16.0.tgz",
-      "integrity": "sha512-4iHjkSYQYw46pITrNQgXXhvUmcekI8INz1m+SzmqLX8jexSSy4Ky4zfGhZzhhhLHXUP3+x/PK/c0qPjxEvRwKQ=="
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.19.1.tgz",
+      "integrity": "sha512-XGghi3l0qA38HiqdoUY+wvGyBsGvKZ6U3vTiMBT4hArhP3fOGLXpIINgMiiGjTe4FVlTa5a/7Zf2bwlIHfRqqg=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.16.0.tgz",
-      "integrity": "sha512-p7RYykvA6Ip6QENxrh99nOD77otVh1sJRivcgcVpnjoZb5sIN3t33eUY1DpB9QSBizcrW+qk19rNkdnZ43a+PQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.19.1.tgz",
+      "integrity": "sha512-+PDWL+XALGvIginigzu8oU6eWw+o76Z8zHbBovWYcrtWOEtinbl7a7UTt3x3lthv+wNuFr/YD1Gf+B+A9V8n5w==",
       "dependencies": {
-        "@algolia/cache-common": "4.16.0"
+        "@algolia/cache-common": "4.19.1"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.16.0.tgz",
-      "integrity": "sha512-eydcfpdIyuWoKgUSz5iZ/L0wE/Wl7958kACkvTHLDNXvK/b8Z1zypoJavh6/km1ZNQmFpeYS2jrmq0kUSFn02w==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.19.1.tgz",
+      "integrity": "sha512-Oy0ritA2k7AMxQ2JwNpfaEcgXEDgeyKu0V7E7xt/ZJRdXfEpZcwp9TOg4TJHC7Ia62gIeT2Y/ynzsxccPw92GA==",
       "dependencies": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.16.0.tgz",
-      "integrity": "sha512-cONWXH3BfilgdlCofUm492bJRWtpBLVW/hsUlfoFtiX1u05xoBP7qeiDwh9RR+4pSLHLodYkHAf5U4honQ55Qg==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.19.1.tgz",
+      "integrity": "sha512-5QCq2zmgdZLIQhHqwl55ZvKVpLM3DNWjFI4T+bHr3rGu23ew2bLO4YtyxaZeChmDb85jUdPDouDlCumGfk6wOg==",
       "dependencies": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.16.0.tgz",
-      "integrity": "sha512-QVdR4019ukBH6f5lFr27W60trRxQF1SfS1qo0IP6gjsKhXhUVJuHxOCA6ArF87jrNkeuHEoRoDU+GlvaecNo8g==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.19.1.tgz",
+      "integrity": "sha512-3kAIVqTcPrjfS389KQvKzliC559x+BDRxtWamVJt8IVp7LGnjq+aVAXg4Xogkur1MUrScTZ59/AaUd5EdpyXgA==",
       "dependencies": {
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.16.0.tgz",
-      "integrity": "sha512-irtLafssDGPuhYqIwxqOxiWlVYvrsBD+EMA1P9VJtkKi3vSNBxiWeQ0f0Tn53cUNdSRNEssfoEH84JL97SV2SQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.19.1.tgz",
+      "integrity": "sha512-8CWz4/H5FA+krm9HMw2HUQenizC/DxUtsI5oYC0Jxxyce1vsr8cb1aEiSJArQT6IzMynrERif1RVWLac1m36xw==",
       "dependencies": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.16.0.tgz",
-      "integrity": "sha512-xsfrAE1jO/JDh1wFrRz+alVyW+aA6qnkzmbWWWZWEgVF3EaFqzIf9r1l/aDtDdBtNTNhX9H3Lg31+BRtd5izQA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.19.1.tgz",
+      "integrity": "sha512-mBecfMFS4N+yK/p0ZbK53vrZbL6OtWMk8YmnOv1i0LXx4pelY8TFhqKoTit3NPVPwoSNN0vdSN9dTu1xr1XOVw==",
       "dependencies": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "node_modules/@algolia/events": {
@@ -125,47 +141,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.16.0.tgz",
-      "integrity": "sha512-U9H8uCzSDuePJmbnjjTX21aPDRU6x74Tdq3dJmdYu2+pISx02UeBJm4kSgc9RW5jcR5j35G9gnjHY9Q3ngWbyQ=="
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.19.1.tgz",
+      "integrity": "sha512-i6pLPZW/+/YXKis8gpmSiNk1lOmYCmRI6+x6d2Qk1OdfvX051nRVdalRbEcVTpSQX6FQAoyeaui0cUfLYW5Elw=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.16.0.tgz",
-      "integrity": "sha512-+qymusiM+lPZKrkf0tDjCQA158eEJO2IU+Nr/sJ9TFyI/xkFPjNPzw/Qbc8Iy/xcOXGlc6eMgmyjtVQqAWq6UA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.19.1.tgz",
+      "integrity": "sha512-jj72k9GKb9W0c7TyC3cuZtTr0CngLBLmc8trzZlXdfvQiigpUdvTi1KoWIb2ZMcRBG7Tl8hSb81zEY3zI2RlXg==",
       "dependencies": {
-        "@algolia/logger-common": "4.16.0"
+        "@algolia/logger-common": "4.19.1"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.16.0.tgz",
-      "integrity": "sha512-gK+kvs6LHl/PaOJfDuwjkopNbG1djzFLsVBklGBsSU6h6VjFkxIpo6Qq80IK14p9cplYZfhfaL12va6Q9p3KVQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.19.1.tgz",
+      "integrity": "sha512-09K/+t7lptsweRTueHnSnmPqIxbHMowejAkn9XIcJMLdseS3zl8ObnS5GWea86mu3vy4+8H+ZBKkUN82Zsq/zg==",
       "dependencies": {
-        "@algolia/requester-common": "4.16.0"
+        "@algolia/requester-common": "4.19.1"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.16.0.tgz",
-      "integrity": "sha512-3Zmcs/iMubcm4zqZ3vZG6Zum8t+hMWxGMzo0/uY2BD8o9q5vMxIYI0c4ocdgQjkXcix189WtZNkgjSOBzSbkdw=="
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.19.1.tgz",
+      "integrity": "sha512-BisRkcWVxrDzF1YPhAckmi2CFYK+jdMT60q10d7z3PX+w6fPPukxHRnZwooiTUrzFe50UBmLItGizWHP5bDzVQ=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.16.0.tgz",
-      "integrity": "sha512-L8JxM2VwZzh8LJ1Zb8TFS6G3icYsCKZsdWW+ahcEs1rGWmyk9SybsOe1MLnjonGBaqPWJkn9NjS7mRdjEmBtKA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.19.1.tgz",
+      "integrity": "sha512-6DK52DHviBHTG2BK/Vv2GIlEw7i+vxm7ypZW0Z7vybGCNDeWzADx+/TmxjkES2h15+FZOqVf/Ja677gePsVItA==",
       "dependencies": {
-        "@algolia/requester-common": "4.16.0"
+        "@algolia/requester-common": "4.19.1"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.16.0.tgz",
-      "integrity": "sha512-H9BVB2EAjT65w7XGBNf5drpsW39x2aSZ942j4boSAAJPPlLmjtj5IpAP7UAtsV8g9Beslonh0bLa1XGmE/P0BA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.19.1.tgz",
+      "integrity": "sha512-nkpvPWbpuzxo1flEYqNIbGz7xhfhGOKGAZS7tzC+TELgEmi7z99qRyTfNSUlW7LZmB3ACdnqAo+9A9KFBENviQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.16.0",
-        "@algolia/logger-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0"
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -229,9 +245,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -303,9 +319,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -362,9 +378,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1563,9 +1579,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1775,9 +1791,9 @@
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1911,24 +1927,25 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
-      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
-      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.7.4",
-        "@algolia/autocomplete-preset-algolia": "1.7.4",
-        "@docsearch/css": "3.3.3",
-        "algoliasearch": "^4.0.0"
+        "@algolia/autocomplete-core": "1.9.3",
+        "@algolia/autocomplete-preset-algolia": "1.9.3",
+        "@docsearch/css": "3.5.2",
+        "algoliasearch": "^4.19.1"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 19.0.0",
         "react": ">= 16.8.0 < 19.0.0",
-        "react-dom": ">= 16.8.0 < 19.0.0"
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -1939,13 +1956,16 @@
         },
         "react-dom": {
           "optional": true
+        },
+        "search-insights": {
+          "optional": true
         }
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
+      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -1957,13 +1977,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/cssnano-preset": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2031,9 +2051,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
-      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
+      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2045,9 +2065,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
-      "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.1.tgz",
+      "integrity": "sha512-5h5ysIIWYIDHyTVd8BjheZmQZmEgWDR54aQ1BX9pjFfpyzFo5puKXKYrYJXbjEHGyVhEzmB9UXwbxGfaZhOjcg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2057,14 +2077,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
-      "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.1.tgz",
+      "integrity": "sha512-4KhUhEavteIAmbBj7LVFnrVYDiU51H5YWW1zY6SmBSte/YLhDutztLTBE0PQl1Grux1jzUJeaSvAzHpTn6JJDQ==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2088,12 +2108,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
-      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.1.tgz",
+      "integrity": "sha512-gLBuIFM8Dp2XOCWffUDSjtxY7jQgKvYujt7Mx5s4FCTfoL5dN1EVbnrn+O2Wvh8b0a77D57qoIDY7ghgmatR1A==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.4.0",
+        "@docusaurus/types": "2.4.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2107,15 +2127,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.0.tgz",
-      "integrity": "sha512-HsS+Dc2ZLWhfpjYJ5LIrOB/XfXZcElcC7o1iA4yIVtiFz+LHhwP863fhqbwSJ1c6tNDOYBH3HwbskHrc/PIn7Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.1.tgz",
+      "integrity": "sha512-tp0j16gaLIJ4p+IR0P6KDOFsTOGGMY54MNPnmM61Vaqqt5omLqsuKUO8UlCGU1oW/4EIQOhXYy99XYY5MjE+7A==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
@@ -2130,17 +2150,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz",
-      "integrity": "sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.1.tgz",
+      "integrity": "sha512-E2i7Knz5YIbE1XELI6RlTnZnGgS52cUO4BlCiCUCvQHbR+s1xeIWz4C6BtaVnlug0Ccz7nFSksfwDpVlkujg5Q==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2160,17 +2180,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
-      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.1.tgz",
+      "integrity": "sha512-Lo7lSIcpswa2Kv4HEeUcGYqaasMUQNpjTXpV0N8G6jXgZaQurqp7E8NGYeGbDXnb48czmHWbzDL4S3+BbK0VzA==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/module-type-aliases": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2190,15 +2210,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz",
-      "integrity": "sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.1.tgz",
+      "integrity": "sha512-/UjuH/76KLaUlL+o1OvyORynv6FURzjurSjvn2lbWTFc4tpYY2qLYTlKpTCBVPhlLUQsfyFnshEJDLmPneq2oA==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2212,13 +2232,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz",
-      "integrity": "sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.1.tgz",
+      "integrity": "sha512-7Yu9UPzRShlrH/G8btOpR0e6INFZr0EegWplMjOqelIwAcx3PKyR8mgPTxGTxcqiYj6hxSCRN0D8R7YrzImwNA==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2232,13 +2252,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
-      "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.1.tgz",
+      "integrity": "sha512-dyZJdJiCoL+rcfnm0RPkLt/o732HvLiEwmtoNzOoz9MSZz117UH2J6U2vUDtzUzwtFLIf32KkeyzisbwUCgcaQ==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2250,13 +2270,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
-      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.1.tgz",
+      "integrity": "sha512-mKIefK+2kGTQBYvloNEKtDmnRD7bxHLsBcxgnbt4oZwzi2nxCGjPX6+9SQO2KCN5HZbNrYmGo5GJfMgoRvy6uA==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2268,13 +2288,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
-      "integrity": "sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.1.tgz",
+      "integrity": "sha512-Zg4Ii9CMOLfpeV2nG74lVTWNtisFaH9QNtEw48R5QE1KIwDBdTVaiSA18G1EujZjrzJJzXN79VhINSbOJO/r3g==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2286,16 +2306,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz",
-      "integrity": "sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.1.tgz",
+      "integrity": "sha512-lZx+ijt/+atQ3FVE8FOHV/+X3kuok688OydDXrqKRJyXBJZKgGjA2Qa8RjQ4f27V2woaXhtnyrdPop/+OjVMRg==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2309,23 +2329,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz",
-      "integrity": "sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.1.tgz",
+      "integrity": "sha512-P4//+I4zDqQJ+UDgoFrjIFaQ1MeS9UD1cvxVQaI6O7iBmiHQm0MGROP1TbE7HlxlDPXFJjZUK3x3cAoK63smGQ==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/plugin-content-blog": "2.4.0",
-        "@docusaurus/plugin-content-docs": "2.4.0",
-        "@docusaurus/plugin-content-pages": "2.4.0",
-        "@docusaurus/plugin-debug": "2.4.0",
-        "@docusaurus/plugin-google-analytics": "2.4.0",
-        "@docusaurus/plugin-google-gtag": "2.4.0",
-        "@docusaurus/plugin-google-tag-manager": "2.4.0",
-        "@docusaurus/plugin-sitemap": "2.4.0",
-        "@docusaurus/theme-classic": "2.4.0",
-        "@docusaurus/theme-common": "2.4.0",
-        "@docusaurus/theme-search-algolia": "2.4.0",
-        "@docusaurus/types": "2.4.0"
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/plugin-debug": "2.4.1",
+        "@docusaurus/plugin-google-analytics": "2.4.1",
+        "@docusaurus/plugin-google-gtag": "2.4.1",
+        "@docusaurus/plugin-google-tag-manager": "2.4.1",
+        "@docusaurus/plugin-sitemap": "2.4.1",
+        "@docusaurus/theme-classic": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-search-algolia": "2.4.1",
+        "@docusaurus/types": "2.4.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -2348,22 +2368,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz",
-      "integrity": "sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.1.tgz",
+      "integrity": "sha512-Rz0wKUa+LTW1PLXmwnf8mn85EBzaGSt6qamqtmnh9Hflkc+EqiYMhtUJeLdV+wsgYq4aG0ANc+bpUDpsUhdnwg==",
       "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/module-type-aliases": "2.4.0",
-        "@docusaurus/plugin-content-blog": "2.4.0",
-        "@docusaurus/plugin-content-docs": "2.4.0",
-        "@docusaurus/plugin-content-pages": "2.4.0",
-        "@docusaurus/theme-common": "2.4.0",
-        "@docusaurus/theme-translations": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-translations": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2387,17 +2407,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.0.tgz",
-      "integrity": "sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.1.tgz",
+      "integrity": "sha512-G7Zau1W5rQTaFFB3x3soQoZpkgMbl/SYNG8PfMFIjKa3M3q8n0m/GRf5/H/e5BqOvt8c+ZWIXGCiz+kUCSHovA==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/module-type-aliases": "2.4.0",
-        "@docusaurus/plugin-content-blog": "2.4.0",
-        "@docusaurus/plugin-content-docs": "2.4.0",
-        "@docusaurus/plugin-content-pages": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2417,18 +2437,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz",
-      "integrity": "sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.1.tgz",
+      "integrity": "sha512-6BcqW2lnLhZCXuMAvPRezFs1DpmEKzXFKlYjruuas+Xy3AQeFzDJKTJFIm49N77WFCTyxff8d3E4Q9pi/+5McQ==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/plugin-content-docs": "2.4.0",
-        "@docusaurus/theme-common": "2.4.0",
-        "@docusaurus/theme-translations": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-translations": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -2447,9 +2467,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
-      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.1.tgz",
+      "integrity": "sha512-T1RAGP+f86CA1kfE8ejZ3T3pUU3XcyvrGMfC/zxCtc2BsnoexuNI9Vk2CmuKCb+Tacvhxjv5unhxXce0+NKyvA==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2459,9 +2479,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.1.tgz",
+      "integrity": "sha512-0R+cbhpMkhbRXX138UOc/2XZFF8hiZa6ooZAEEJFp5scytzCw4tC1gChMFXrpa3d2tYE6AX8IrOEpSonLmfQuQ==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2478,11 +2498,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
-      "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-1lvEZdAQhKNht9aPXPoh69eeKnV0/62ROhQeFKKxmzd0zkcuE/Oc5Gpnt00y/f5bIsmOsYMY7Pqfm/5rteT5GA==",
       "dependencies": {
-        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/logger": "2.4.1",
         "@svgr/webpack": "^6.2.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2512,9 +2532,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
-      "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.1.tgz",
+      "integrity": "sha512-bCVGdZU+z/qVcIiEQdyx0K13OC5mYwxhSuDUR95oFbKVuXYRrTVrwZIqQljuo1fyJvFTKHiL9L9skQOPokuFNQ==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2531,12 +2551,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
-      "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.1.tgz",
+      "integrity": "sha512-unII3hlJlDwZ3w8U+pMO3Lx3RhI4YEbY3YNsQj4yzrkZzlpqZOLuAiZK2JyULnD+TKbceKU0WyWkQXtYbLNDFA==",
       "dependencies": {
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -2710,9 +2730,9 @@
       }
     },
     "node_modules/@mdx-js/mdx/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -3189,11 +3209,11 @@
       }
     },
     "node_modules/@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.5.tgz",
+      "integrity": "sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==",
       "dependencies": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "node_modules/@types/history": {
@@ -3220,11 +3240,11 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/mdast": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
-      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
+      "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
       "dependencies": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "node_modules/@types/mime": {
@@ -3282,13 +3302,13 @@
       }
     },
     "node_modules/@types/react-router-config": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.6.tgz",
-      "integrity": "sha512-db1mx37a1EJDf1XeX8jJN7R3PZABmJQXR8r28yUjVMFSjkmnQo6X6pOEEmNl+Tp2gYQOGPdYbFIipBtdElZ3Yg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.7.tgz",
+      "integrity": "sha512-pFFVXUIydHlcJP6wJm7sDii5mD/bCmmAY0wQzq+M+uX7bqS95AQqHZWP1iNMKrWVQSuHIzj5qi9BvrtLX2/T4w==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
-        "@types/react-router": "*"
+        "@types/react-router": "^5.1.0"
       }
     },
     "node_modules/@types/react-router-dom": {
@@ -3345,9 +3365,9 @@
       }
     },
     "node_modules/@types/unist": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+      "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -3617,30 +3637,30 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.16.0.tgz",
-      "integrity": "sha512-HAjKJ6bBblaXqO4dYygF4qx251GuJ6zCZt+qbJ+kU7sOC+yc84pawEjVpJByh+cGP2APFCsao2Giz50cDlKNPA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.19.1.tgz",
+      "integrity": "sha512-IJF5b93b2MgAzcE/tuzW0yOPnuUyRgGAtaPv5UUywXM8kzqfdwZTO4sPJBzoGz1eOy6H9uEchsJsBFTELZSu+g==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.16.0",
-        "@algolia/cache-common": "4.16.0",
-        "@algolia/cache-in-memory": "4.16.0",
-        "@algolia/client-account": "4.16.0",
-        "@algolia/client-analytics": "4.16.0",
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-personalization": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/logger-common": "4.16.0",
-        "@algolia/logger-console": "4.16.0",
-        "@algolia/requester-browser-xhr": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/requester-node-http": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/cache-browser-local-storage": "4.19.1",
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/cache-in-memory": "4.19.1",
+        "@algolia/client-account": "4.19.1",
+        "@algolia/client-analytics": "4.19.1",
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-personalization": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/logger-console": "4.19.1",
+        "@algolia/requester-browser-xhr": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/requester-node-http": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz",
-      "integrity": "sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.14.0.tgz",
+      "integrity": "sha512-gXDXzsSS0YANn5dHr71CUXOo84cN4azhHKUbg71vAWnH+1JBiR4jf7to3t3JHXknXkbV0F7f055vUSBKrltHLQ==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -3797,9 +3817,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.14",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+      "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
       "funding": [
         {
           "type": "opencollective",
@@ -3808,11 +3828,15 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001464",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001520",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -3931,9 +3955,9 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4103,9 +4127,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4114,13 +4138,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.11"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4249,9 +4277,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001470",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
-      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -4260,6 +4288,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -4442,22 +4474,22 @@
       }
     },
     "node_modules/cheerio-select/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
+        "domhandler": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/cheerio-select/node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
       },
@@ -4493,22 +4525,22 @@
       }
     },
     "node_modules/cheerio/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
+        "domhandler": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/cheerio/node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
       },
@@ -4875,9 +4907,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/copy-text-to-clipboard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
-      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz",
+      "integrity": "sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==",
       "engines": {
         "node": ">=12"
       },
@@ -5008,24 +5040,15 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.24.1.tgz",
-      "integrity": "sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==",
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.32.1.tgz",
+      "integrity": "sha512-GSvKDv4wE0bPnQtjklV101juQ85g6H3rm5PDP20mqlS5j0kXF3pP97YvAu5hl+uFHqMictp3b2VxOHljWMAtuA==",
       "dependencies": {
-        "browserslist": "^4.21.3",
-        "semver": "7.0.0"
+        "browserslist": "^4.21.10"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-compat/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/core-js-pure": {
@@ -5059,11 +5082,11 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
       "dependencies": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -5667,9 +5690,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+      "version": "1.4.506",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.506.tgz",
+      "integrity": "sha512-xxGct4GPAKSRlrLBtJxJFYy74W11zX6PO9GyHgl/U+2s3Dp0ZEwAklDfNHXOWcvH7zWMpsmgbR0ggEuaYAVvHA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -6080,9 +6103,9 @@
       }
     },
     "node_modules/fbjs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
-      "integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "fbjs-css-vars": "^1.0.0",
@@ -6090,7 +6113,7 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
+        "ua-parser-js": "^1.0.35"
       }
     },
     "node_modules/fbjs-css-vars": {
@@ -6337,15 +6360,15 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.4.tgz",
+      "integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==",
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -8119,9 +8142,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8468,9 +8491,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -8495,9 +8518,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -8746,9 +8769,9 @@
       }
     },
     "node_modules/package-json/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8850,9 +8873,9 @@
       }
     },
     "node_modules/parse5/node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
       },
@@ -9523,9 +9546,9 @@
       }
     },
     "node_modules/postcss-sort-media-queries": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.3.0.tgz",
-      "integrity": "sha512-jAl8gJM2DvuIJiI9sL1CuiHtKM4s5aEIomkU8G3LFvbP+p8i7Sz8VV63uieTgoewGqKbi+hxBTiOKJlB35upCg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.4.1.tgz",
+      "integrity": "sha512-QDESFzDDGKgpiIh4GYXsSy6sek2yAwQx1JASl5AxBtU1Lq2JfKBljIPNdil989NcSKRQX1ToiaKphImtBuhXWw==",
       "dependencies": {
         "sort-css-media-queries": "2.1.0"
       },
@@ -10131,9 +10154,9 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
-      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
+      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -10394,9 +10417,9 @@
       }
     },
     "node_modules/remark-mdx/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -10751,6 +10774,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/search-insights": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.0.tgz",
+      "integrity": "sha512-VzI4PMktJbydkbrF3/n40vFfRxdwg+o3CkQt0F3mHRSXVuv0PsVxQvB6mQQq/e9MCXAemcmp/GP9CNHpayFoCw==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -10780,9 +10812,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10805,9 +10837,9 @@
       }
     },
     "node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -11607,9 +11639,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+      "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==",
       "deprecated": "Use String.prototype.trim() instead"
     },
     "node_modules/trim-trailing-lines": {
@@ -11680,9 +11712,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.34.tgz",
-      "integrity": "sha512-cJMeh/eOILyGu0ejgTKB95yKT3zOenSe9UGE3vj6WfiOwgGYnmATUsnDixMFvdU+rNMvWih83hrUP8VwhF9yXQ==",
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -11890,9 +11922,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "funding": [
         {
           "type": "opencollective",
@@ -11901,6 +11933,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -11908,7 +11944,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -12822,95 +12858,105 @@
   },
   "dependencies": {
     "@algolia/autocomplete-core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
-      "integrity": "sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.4"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.9.3"
       }
     },
     "@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
-      "integrity": "sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.4"
+        "@algolia/autocomplete-shared": "1.9.3"
       }
     },
     "@algolia/autocomplete-shared": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
-      "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "requires": {}
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.16.0.tgz",
-      "integrity": "sha512-jVrk0YB3tjOhD5/lhBtYCVCeLjZmVpf2kdi4puApofytf/R0scjWz0GdozlW4HhU+Prxmt/c9ge4QFjtv5OAzQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.19.1.tgz",
+      "integrity": "sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==",
       "requires": {
-        "@algolia/cache-common": "4.16.0"
+        "@algolia/cache-common": "4.19.1"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.16.0.tgz",
-      "integrity": "sha512-4iHjkSYQYw46pITrNQgXXhvUmcekI8INz1m+SzmqLX8jexSSy4Ky4zfGhZzhhhLHXUP3+x/PK/c0qPjxEvRwKQ=="
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.19.1.tgz",
+      "integrity": "sha512-XGghi3l0qA38HiqdoUY+wvGyBsGvKZ6U3vTiMBT4hArhP3fOGLXpIINgMiiGjTe4FVlTa5a/7Zf2bwlIHfRqqg=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.16.0.tgz",
-      "integrity": "sha512-p7RYykvA6Ip6QENxrh99nOD77otVh1sJRivcgcVpnjoZb5sIN3t33eUY1DpB9QSBizcrW+qk19rNkdnZ43a+PQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.19.1.tgz",
+      "integrity": "sha512-+PDWL+XALGvIginigzu8oU6eWw+o76Z8zHbBovWYcrtWOEtinbl7a7UTt3x3lthv+wNuFr/YD1Gf+B+A9V8n5w==",
       "requires": {
-        "@algolia/cache-common": "4.16.0"
+        "@algolia/cache-common": "4.19.1"
       }
     },
     "@algolia/client-account": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.16.0.tgz",
-      "integrity": "sha512-eydcfpdIyuWoKgUSz5iZ/L0wE/Wl7958kACkvTHLDNXvK/b8Z1zypoJavh6/km1ZNQmFpeYS2jrmq0kUSFn02w==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.19.1.tgz",
+      "integrity": "sha512-Oy0ritA2k7AMxQ2JwNpfaEcgXEDgeyKu0V7E7xt/ZJRdXfEpZcwp9TOg4TJHC7Ia62gIeT2Y/ynzsxccPw92GA==",
       "requires": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.16.0.tgz",
-      "integrity": "sha512-cONWXH3BfilgdlCofUm492bJRWtpBLVW/hsUlfoFtiX1u05xoBP7qeiDwh9RR+4pSLHLodYkHAf5U4honQ55Qg==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.19.1.tgz",
+      "integrity": "sha512-5QCq2zmgdZLIQhHqwl55ZvKVpLM3DNWjFI4T+bHr3rGu23ew2bLO4YtyxaZeChmDb85jUdPDouDlCumGfk6wOg==",
       "requires": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "@algolia/client-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.16.0.tgz",
-      "integrity": "sha512-QVdR4019ukBH6f5lFr27W60trRxQF1SfS1qo0IP6gjsKhXhUVJuHxOCA6ArF87jrNkeuHEoRoDU+GlvaecNo8g==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.19.1.tgz",
+      "integrity": "sha512-3kAIVqTcPrjfS389KQvKzliC559x+BDRxtWamVJt8IVp7LGnjq+aVAXg4Xogkur1MUrScTZ59/AaUd5EdpyXgA==",
       "requires": {
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.16.0.tgz",
-      "integrity": "sha512-irtLafssDGPuhYqIwxqOxiWlVYvrsBD+EMA1P9VJtkKi3vSNBxiWeQ0f0Tn53cUNdSRNEssfoEH84JL97SV2SQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.19.1.tgz",
+      "integrity": "sha512-8CWz4/H5FA+krm9HMw2HUQenizC/DxUtsI5oYC0Jxxyce1vsr8cb1aEiSJArQT6IzMynrERif1RVWLac1m36xw==",
       "requires": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "@algolia/client-search": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.16.0.tgz",
-      "integrity": "sha512-xsfrAE1jO/JDh1wFrRz+alVyW+aA6qnkzmbWWWZWEgVF3EaFqzIf9r1l/aDtDdBtNTNhX9H3Lg31+BRtd5izQA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.19.1.tgz",
+      "integrity": "sha512-mBecfMFS4N+yK/p0ZbK53vrZbL6OtWMk8YmnOv1i0LXx4pelY8TFhqKoTit3NPVPwoSNN0vdSN9dTu1xr1XOVw==",
       "requires": {
-        "@algolia/client-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "@algolia/events": {
@@ -12919,47 +12965,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.16.0.tgz",
-      "integrity": "sha512-U9H8uCzSDuePJmbnjjTX21aPDRU6x74Tdq3dJmdYu2+pISx02UeBJm4kSgc9RW5jcR5j35G9gnjHY9Q3ngWbyQ=="
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.19.1.tgz",
+      "integrity": "sha512-i6pLPZW/+/YXKis8gpmSiNk1lOmYCmRI6+x6d2Qk1OdfvX051nRVdalRbEcVTpSQX6FQAoyeaui0cUfLYW5Elw=="
     },
     "@algolia/logger-console": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.16.0.tgz",
-      "integrity": "sha512-+qymusiM+lPZKrkf0tDjCQA158eEJO2IU+Nr/sJ9TFyI/xkFPjNPzw/Qbc8Iy/xcOXGlc6eMgmyjtVQqAWq6UA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.19.1.tgz",
+      "integrity": "sha512-jj72k9GKb9W0c7TyC3cuZtTr0CngLBLmc8trzZlXdfvQiigpUdvTi1KoWIb2ZMcRBG7Tl8hSb81zEY3zI2RlXg==",
       "requires": {
-        "@algolia/logger-common": "4.16.0"
+        "@algolia/logger-common": "4.19.1"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.16.0.tgz",
-      "integrity": "sha512-gK+kvs6LHl/PaOJfDuwjkopNbG1djzFLsVBklGBsSU6h6VjFkxIpo6Qq80IK14p9cplYZfhfaL12va6Q9p3KVQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.19.1.tgz",
+      "integrity": "sha512-09K/+t7lptsweRTueHnSnmPqIxbHMowejAkn9XIcJMLdseS3zl8ObnS5GWea86mu3vy4+8H+ZBKkUN82Zsq/zg==",
       "requires": {
-        "@algolia/requester-common": "4.16.0"
+        "@algolia/requester-common": "4.19.1"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.16.0.tgz",
-      "integrity": "sha512-3Zmcs/iMubcm4zqZ3vZG6Zum8t+hMWxGMzo0/uY2BD8o9q5vMxIYI0c4ocdgQjkXcix189WtZNkgjSOBzSbkdw=="
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.19.1.tgz",
+      "integrity": "sha512-BisRkcWVxrDzF1YPhAckmi2CFYK+jdMT60q10d7z3PX+w6fPPukxHRnZwooiTUrzFe50UBmLItGizWHP5bDzVQ=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.16.0.tgz",
-      "integrity": "sha512-L8JxM2VwZzh8LJ1Zb8TFS6G3icYsCKZsdWW+ahcEs1rGWmyk9SybsOe1MLnjonGBaqPWJkn9NjS7mRdjEmBtKA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.19.1.tgz",
+      "integrity": "sha512-6DK52DHviBHTG2BK/Vv2GIlEw7i+vxm7ypZW0Z7vybGCNDeWzADx+/TmxjkES2h15+FZOqVf/Ja677gePsVItA==",
       "requires": {
-        "@algolia/requester-common": "4.16.0"
+        "@algolia/requester-common": "4.19.1"
       }
     },
     "@algolia/transporter": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.16.0.tgz",
-      "integrity": "sha512-H9BVB2EAjT65w7XGBNf5drpsW39x2aSZ942j4boSAAJPPlLmjtj5IpAP7UAtsV8g9Beslonh0bLa1XGmE/P0BA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.19.1.tgz",
+      "integrity": "sha512-nkpvPWbpuzxo1flEYqNIbGz7xhfhGOKGAZS7tzC+TELgEmi7z99qRyTfNSUlW7LZmB3ACdnqAo+9A9KFBENviQ==",
       "requires": {
-        "@algolia/cache-common": "4.16.0",
-        "@algolia/logger-common": "4.16.0",
-        "@algolia/requester-common": "4.16.0"
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1"
       }
     },
     "@ampproject/remapping": {
@@ -13007,9 +13053,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -13064,9 +13110,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -13107,9 +13153,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -13880,9 +13926,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -14037,9 +14083,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -14139,25 +14185,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
-      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA=="
     },
     "@docsearch/react": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
-      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
       "requires": {
-        "@algolia/autocomplete-core": "1.7.4",
-        "@algolia/autocomplete-preset-algolia": "1.7.4",
-        "@docsearch/css": "3.3.3",
-        "algoliasearch": "^4.0.0"
+        "@algolia/autocomplete-core": "1.9.3",
+        "@algolia/autocomplete-preset-algolia": "1.9.3",
+        "@docsearch/css": "3.5.2",
+        "algoliasearch": "^4.19.1"
       }
     },
     "@docusaurus/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
+      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -14169,13 +14215,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/cssnano-preset": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -14233,9 +14279,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
-      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
+      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -14244,23 +14290,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
-      "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.1.tgz",
+      "integrity": "sha512-5h5ysIIWYIDHyTVd8BjheZmQZmEgWDR54aQ1BX9pjFfpyzFo5puKXKYrYJXbjEHGyVhEzmB9UXwbxGfaZhOjcg==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
-      "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.1.tgz",
+      "integrity": "sha512-4KhUhEavteIAmbBj7LVFnrVYDiU51H5YWW1zY6SmBSte/YLhDutztLTBE0PQl1Grux1jzUJeaSvAzHpTn6JJDQ==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -14277,12 +14323,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
-      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.1.tgz",
+      "integrity": "sha512-gLBuIFM8Dp2XOCWffUDSjtxY7jQgKvYujt7Mx5s4FCTfoL5dN1EVbnrn+O2Wvh8b0a77D57qoIDY7ghgmatR1A==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.4.0",
+        "@docusaurus/types": "2.4.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14292,15 +14338,15 @@
       }
     },
     "@docusaurus/plugin-client-redirects": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.0.tgz",
-      "integrity": "sha512-HsS+Dc2ZLWhfpjYJ5LIrOB/XfXZcElcC7o1iA4yIVtiFz+LHhwP863fhqbwSJ1c6tNDOYBH3HwbskHrc/PIn7Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.1.tgz",
+      "integrity": "sha512-tp0j16gaLIJ4p+IR0P6KDOFsTOGGMY54MNPnmM61Vaqqt5omLqsuKUO8UlCGU1oW/4EIQOhXYy99XYY5MjE+7A==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
@@ -14308,17 +14354,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz",
-      "integrity": "sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.1.tgz",
+      "integrity": "sha512-E2i7Knz5YIbE1XELI6RlTnZnGgS52cUO4BlCiCUCvQHbR+s1xeIWz4C6BtaVnlug0Ccz7nFSksfwDpVlkujg5Q==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -14331,17 +14377,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
-      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.1.tgz",
+      "integrity": "sha512-Lo7lSIcpswa2Kv4HEeUcGYqaasMUQNpjTXpV0N8G6jXgZaQurqp7E8NGYeGbDXnb48czmHWbzDL4S3+BbK0VzA==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/module-type-aliases": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -14354,100 +14400,100 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz",
-      "integrity": "sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.1.tgz",
+      "integrity": "sha512-/UjuH/76KLaUlL+o1OvyORynv6FURzjurSjvn2lbWTFc4tpYY2qLYTlKpTCBVPhlLUQsfyFnshEJDLmPneq2oA==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz",
-      "integrity": "sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.1.tgz",
+      "integrity": "sha512-7Yu9UPzRShlrH/G8btOpR0e6INFZr0EegWplMjOqelIwAcx3PKyR8mgPTxGTxcqiYj6hxSCRN0D8R7YrzImwNA==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
-      "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.1.tgz",
+      "integrity": "sha512-dyZJdJiCoL+rcfnm0RPkLt/o732HvLiEwmtoNzOoz9MSZz117UH2J6U2vUDtzUzwtFLIf32KkeyzisbwUCgcaQ==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
-      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.1.tgz",
+      "integrity": "sha512-mKIefK+2kGTQBYvloNEKtDmnRD7bxHLsBcxgnbt4oZwzi2nxCGjPX6+9SQO2KCN5HZbNrYmGo5GJfMgoRvy6uA==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-tag-manager": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
-      "integrity": "sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.1.tgz",
+      "integrity": "sha512-Zg4Ii9CMOLfpeV2nG74lVTWNtisFaH9QNtEw48R5QE1KIwDBdTVaiSA18G1EujZjrzJJzXN79VhINSbOJO/r3g==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz",
-      "integrity": "sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.1.tgz",
+      "integrity": "sha512-lZx+ijt/+atQ3FVE8FOHV/+X3kuok688OydDXrqKRJyXBJZKgGjA2Qa8RjQ4f27V2woaXhtnyrdPop/+OjVMRg==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz",
-      "integrity": "sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.1.tgz",
+      "integrity": "sha512-P4//+I4zDqQJ+UDgoFrjIFaQ1MeS9UD1cvxVQaI6O7iBmiHQm0MGROP1TbE7HlxlDPXFJjZUK3x3cAoK63smGQ==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/plugin-content-blog": "2.4.0",
-        "@docusaurus/plugin-content-docs": "2.4.0",
-        "@docusaurus/plugin-content-pages": "2.4.0",
-        "@docusaurus/plugin-debug": "2.4.0",
-        "@docusaurus/plugin-google-analytics": "2.4.0",
-        "@docusaurus/plugin-google-gtag": "2.4.0",
-        "@docusaurus/plugin-google-tag-manager": "2.4.0",
-        "@docusaurus/plugin-sitemap": "2.4.0",
-        "@docusaurus/theme-classic": "2.4.0",
-        "@docusaurus/theme-common": "2.4.0",
-        "@docusaurus/theme-search-algolia": "2.4.0",
-        "@docusaurus/types": "2.4.0"
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/plugin-debug": "2.4.1",
+        "@docusaurus/plugin-google-analytics": "2.4.1",
+        "@docusaurus/plugin-google-gtag": "2.4.1",
+        "@docusaurus/plugin-google-tag-manager": "2.4.1",
+        "@docusaurus/plugin-sitemap": "2.4.1",
+        "@docusaurus/theme-classic": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-search-algolia": "2.4.1",
+        "@docusaurus/types": "2.4.1"
       }
     },
     "@docusaurus/react-loadable": {
@@ -14460,22 +14506,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz",
-      "integrity": "sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.1.tgz",
+      "integrity": "sha512-Rz0wKUa+LTW1PLXmwnf8mn85EBzaGSt6qamqtmnh9Hflkc+EqiYMhtUJeLdV+wsgYq4aG0ANc+bpUDpsUhdnwg==",
       "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/module-type-aliases": "2.4.0",
-        "@docusaurus/plugin-content-blog": "2.4.0",
-        "@docusaurus/plugin-content-docs": "2.4.0",
-        "@docusaurus/plugin-content-pages": "2.4.0",
-        "@docusaurus/theme-common": "2.4.0",
-        "@docusaurus/theme-translations": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-translations": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -14492,17 +14538,17 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.0.tgz",
-      "integrity": "sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.1.tgz",
+      "integrity": "sha512-G7Zau1W5rQTaFFB3x3soQoZpkgMbl/SYNG8PfMFIjKa3M3q8n0m/GRf5/H/e5BqOvt8c+ZWIXGCiz+kUCSHovA==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.4.0",
-        "@docusaurus/module-type-aliases": "2.4.0",
-        "@docusaurus/plugin-content-blog": "2.4.0",
-        "@docusaurus/plugin-content-docs": "2.4.0",
-        "@docusaurus/plugin-content-pages": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14515,18 +14561,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz",
-      "integrity": "sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.1.tgz",
+      "integrity": "sha512-6BcqW2lnLhZCXuMAvPRezFs1DpmEKzXFKlYjruuas+Xy3AQeFzDJKTJFIm49N77WFCTyxff8d3E4Q9pi/+5McQ==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/plugin-content-docs": "2.4.0",
-        "@docusaurus/theme-common": "2.4.0",
-        "@docusaurus/theme-translations": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-translations": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -14538,18 +14584,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
-      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.1.tgz",
+      "integrity": "sha512-T1RAGP+f86CA1kfE8ejZ3T3pUU3XcyvrGMfC/zxCtc2BsnoexuNI9Vk2CmuKCb+Tacvhxjv5unhxXce0+NKyvA==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.1.tgz",
+      "integrity": "sha512-0R+cbhpMkhbRXX138UOc/2XZFF8hiZa6ooZAEEJFp5scytzCw4tC1gChMFXrpa3d2tYE6AX8IrOEpSonLmfQuQ==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -14562,11 +14608,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
-      "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-1lvEZdAQhKNht9aPXPoh69eeKnV0/62ROhQeFKKxmzd0zkcuE/Oc5Gpnt00y/f5bIsmOsYMY7Pqfm/5rteT5GA==",
       "requires": {
-        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/logger": "2.4.1",
         "@svgr/webpack": "^6.2.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -14592,20 +14638,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
-      "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.1.tgz",
+      "integrity": "sha512-bCVGdZU+z/qVcIiEQdyx0K13OC5mYwxhSuDUR95oFbKVuXYRrTVrwZIqQljuo1fyJvFTKHiL9L9skQOPokuFNQ==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
-      "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.1.tgz",
+      "integrity": "sha512-unII3hlJlDwZ3w8U+pMO3Lx3RhI4YEbY3YNsQj4yzrkZzlpqZOLuAiZK2JyULnD+TKbceKU0WyWkQXtYbLNDFA==",
       "requires": {
-        "@docusaurus/logger": "2.4.0",
-        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -14741,9 +14787,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "source-map": {
           "version": "0.5.7",
@@ -15054,11 +15100,11 @@
       }
     },
     "@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.5.tgz",
+      "integrity": "sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==",
       "requires": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "@types/history": {
@@ -15085,11 +15131,11 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/mdast": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
-      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
+      "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
       "requires": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "@types/mime": {
@@ -15147,13 +15193,13 @@
       }
     },
     "@types/react-router-config": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.6.tgz",
-      "integrity": "sha512-db1mx37a1EJDf1XeX8jJN7R3PZABmJQXR8r28yUjVMFSjkmnQo6X6pOEEmNl+Tp2gYQOGPdYbFIipBtdElZ3Yg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.7.tgz",
+      "integrity": "sha512-pFFVXUIydHlcJP6wJm7sDii5mD/bCmmAY0wQzq+M+uX7bqS95AQqHZWP1iNMKrWVQSuHIzj5qi9BvrtLX2/T4w==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
-        "@types/react-router": "*"
+        "@types/react-router": "^5.1.0"
       }
     },
     "@types/react-router-dom": {
@@ -15210,9 +15256,9 @@
       }
     },
     "@types/unist": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
+      "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -15446,30 +15492,30 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.16.0.tgz",
-      "integrity": "sha512-HAjKJ6bBblaXqO4dYygF4qx251GuJ6zCZt+qbJ+kU7sOC+yc84pawEjVpJByh+cGP2APFCsao2Giz50cDlKNPA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.19.1.tgz",
+      "integrity": "sha512-IJF5b93b2MgAzcE/tuzW0yOPnuUyRgGAtaPv5UUywXM8kzqfdwZTO4sPJBzoGz1eOy6H9uEchsJsBFTELZSu+g==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.16.0",
-        "@algolia/cache-common": "4.16.0",
-        "@algolia/cache-in-memory": "4.16.0",
-        "@algolia/client-account": "4.16.0",
-        "@algolia/client-analytics": "4.16.0",
-        "@algolia/client-common": "4.16.0",
-        "@algolia/client-personalization": "4.16.0",
-        "@algolia/client-search": "4.16.0",
-        "@algolia/logger-common": "4.16.0",
-        "@algolia/logger-console": "4.16.0",
-        "@algolia/requester-browser-xhr": "4.16.0",
-        "@algolia/requester-common": "4.16.0",
-        "@algolia/requester-node-http": "4.16.0",
-        "@algolia/transporter": "4.16.0"
+        "@algolia/cache-browser-local-storage": "4.19.1",
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/cache-in-memory": "4.19.1",
+        "@algolia/client-account": "4.19.1",
+        "@algolia/client-analytics": "4.19.1",
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-personalization": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/logger-console": "4.19.1",
+        "@algolia/requester-browser-xhr": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/requester-node-http": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz",
-      "integrity": "sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.14.0.tgz",
+      "integrity": "sha512-gXDXzsSS0YANn5dHr71CUXOo84cN4azhHKUbg71vAWnH+1JBiR4jf7to3t3JHXknXkbV0F7f055vUSBKrltHLQ==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -15585,12 +15631,12 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "autoprefixer": {
-      "version": "10.4.14",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+      "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
       "requires": {
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001464",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001520",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -15678,9 +15724,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -15819,14 +15865,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.11"
       }
     },
     "buffer-from": {
@@ -15918,9 +15964,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001470",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
-      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA=="
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q=="
     },
     "ccount": {
       "version": "1.1.0",
@@ -16020,19 +16066,19 @@
           }
         },
         "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
           "requires": {
             "dom-serializer": "^2.0.0",
             "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
+            "domhandler": "^5.0.3"
           }
         },
         "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         },
         "htmlparser2": {
           "version": "8.0.2",
@@ -16091,19 +16137,19 @@
           }
         },
         "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
           "requires": {
             "dom-serializer": "^2.0.0",
             "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
+            "domhandler": "^5.0.3"
           }
         },
         "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         }
       }
     },
@@ -16365,9 +16411,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "copy-text-to-clipboard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
-      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz",
+      "integrity": "sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q=="
     },
     "copy-webpack-plugin": {
       "version": "11.0.0",
@@ -16450,19 +16496,11 @@
       "integrity": "sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg=="
     },
     "core-js-compat": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.24.1.tgz",
-      "integrity": "sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==",
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.32.1.tgz",
+      "integrity": "sha512-GSvKDv4wE0bPnQtjklV101juQ85g6H3rm5PDP20mqlS5j0kXF3pP97YvAu5hl+uFHqMictp3b2VxOHljWMAtuA==",
       "requires": {
-        "browserslist": "^4.21.3",
-        "semver": "7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
-        }
+        "browserslist": "^4.21.10"
       }
     },
     "core-js-pure": {
@@ -16488,11 +16526,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
       "requires": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "cross-spawn": {
@@ -16912,9 +16950,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+      "version": "1.4.506",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.506.tgz",
+      "integrity": "sha512-xxGct4GPAKSRlrLBtJxJFYy74W11zX6PO9GyHgl/U+2s3Dp0ZEwAklDfNHXOWcvH7zWMpsmgbR0ggEuaYAVvHA=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -17231,9 +17269,9 @@
       }
     },
     "fbjs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
-      "integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
       "requires": {
         "cross-fetch": "^3.1.5",
         "fbjs-css-vars": "^1.0.0",
@@ -17241,7 +17279,7 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
+        "ua-parser-js": "^1.0.35"
       }
     },
     "fbjs-css-vars": {
@@ -17407,9 +17445,9 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA=="
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.4.tgz",
+      "integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q=="
     },
     "fresh": {
       "version": "0.5.2",
@@ -18681,9 +18719,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -18932,9 +18970,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -18945,9 +18983,9 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-releases": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -19115,9 +19153,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -19176,9 +19214,9 @@
       },
       "dependencies": {
         "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         }
       }
     },
@@ -19611,9 +19649,9 @@
       }
     },
     "postcss-sort-media-queries": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.3.0.tgz",
-      "integrity": "sha512-jAl8gJM2DvuIJiI9sL1CuiHtKM4s5aEIomkU8G3LFvbP+p8i7Sz8VV63uieTgoewGqKbi+hxBTiOKJlB35upCg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.4.1.tgz",
+      "integrity": "sha512-QDESFzDDGKgpiIh4GYXsSy6sek2yAwQx1JASl5AxBtU1Lq2JfKBljIPNdil989NcSKRQX1ToiaKphImtBuhXWw==",
       "requires": {
         "sort-css-media-queries": "2.1.0"
       }
@@ -20056,9 +20094,9 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
-      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
+      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -20261,9 +20299,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "source-map": {
           "version": "0.5.7",
@@ -20300,7 +20338,7 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
+        "trim": "0.0.3",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",
@@ -20516,6 +20554,12 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "search-insights": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.0.tgz",
+      "integrity": "sha512-VzI4PMktJbydkbrF3/n40vFfRxdwg+o3CkQt0F3mHRSXVuv0PsVxQvB6mQQq/e9MCXAemcmp/GP9CNHpayFoCw==",
+      "peer": true
+    },
     "section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -20539,9 +20583,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -20555,9 +20599,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -21163,9 +21207,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+      "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
     },
     "trim-trailing-lines": {
       "version": "1.1.4",
@@ -21211,9 +21255,9 @@
       "peer": true
     },
     "ua-parser-js": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.34.tgz",
-      "integrity": "sha512-cJMeh/eOILyGu0ejgTKB95yKT3zOenSe9UGE3vj6WfiOwgGYnmATUsnDixMFvdU+rNMvWih83hrUP8VwhF9yXQ=="
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA=="
     },
     "unherit": {
       "version": "1.1.3",
@@ -21343,9 +21387,9 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -16,14 +16,17 @@
     "format:fix": "prettier --write '**/*.{js,jsx}'"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.4.0",
-    "@docusaurus/plugin-client-redirects": "^2.4.0",
-    "@docusaurus/preset-classic": "^2.4.0",
+    "@docusaurus/core": "^2.4.1",
+    "@docusaurus/plugin-client-redirects": "^2.4.1",
+    "@docusaurus/preset-classic": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
     "prism-react-renderer": "^1.3.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
+  },
+  "overrides": {
+    "trim" : "0.0.3"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
```
@docusaurus/core@2.4.1 > @docusaurus/mdx-loader@2.4.1 > @mdx-js/mdx@1.6.22 > remark-mdx@1.6.22 > remark-parse@8.0.3 > trim@0.0.1
```
`trim` is fixed at `0.0.1` by  [remark-parse 8.0.3](https://www.npmjs.com/package/remark-parse/v/8.0.3?activeTab=code) Upgrading to 0.0.3 fixes the issue and unlocks allows to address other dependency vulnerabilities. 

A check of the diff between [trim 0.0.1 and 0.0.3](https://github.com/Trott/trim/compare/0.0.1...v0.0.3) shows that the functionality should not be impacted despite [this](https://github.com/remarkjs/remark/issues/710). This is confirmed by testing the documentation locally.
